### PR TITLE
Fix layout bug caused by floating point rounding error

### DIFF
--- a/tests/YGRoundingFunctionTest.cpp
+++ b/tests/YGRoundingFunctionTest.cpp
@@ -181,3 +181,27 @@ TEST(YogaTest, raw_layout_dimensions) {
 
   YGConfigFree(config);
 }
+
+TEST(YogaTest, roundLayoutResultsToPixelGrid_height_rounding_up) {
+  YGConfigRef config = YGConfigNew();
+  YGConfigSetPointScaleFactor(config, 3);
+
+  YGNodeRef node = YGNodeNewWithConfig(config);
+  YGNodeStyleSetPositionType(node, YGPositionTypeAbsolute);
+
+  // These are values extracted from a debugging session in a real iOS app
+  YGNodeStyleSetPosition(node, YGEdgeLeft, 38.333333969116211);
+  YGNodeStyleSetPosition(node, YGEdgeTop, 1970.3333333432674);
+  YGNodeStyleSetWidth(node, 339.66665649414063);
+  YGNodeStyleSetHeight(node, 96);
+  YGNodeSetNodeType(node, YGNodeTypeText);
+
+  YGNodeCalculateLayout(node, YGUndefined, YGUndefined, YGDirectionLTR);
+
+  // If this value is anything less than 96, iOS will not wrap the text to a 4th line
+  ASSERT_FLOAT_EQ(YGNodeLayoutGetHeight(node), 96.0f);
+
+  YGNodeFreeRecursive(node);
+
+  YGConfigFree(config);
+}

--- a/yoga/algorithm/PixelGrid.cpp
+++ b/yoga/algorithm/PixelGrid.cpp
@@ -116,15 +116,23 @@ void roundLayoutResultsToPixelGrid(
             roundValueToPixelGrid(
                 absoluteNodeLeft, pointScaleFactor, false, textRounding));
 
-    node->getLayout().setDimension(
-        Dimension::Height,
-        roundValueToPixelGrid(
-            absoluteNodeBottom,
-            pointScaleFactor,
-            (textRounding && hasFractionalHeight),
-            (textRounding && !hasFractionalHeight)) -
-            roundValueToPixelGrid(
-                absoluteNodeTop, pointScaleFactor, false, textRounding));
+    // -- Height --
+    const float roundedBottom = roundValueToPixelGrid(
+        absoluteNodeBottom,
+        pointScaleFactor,
+        (textRounding && hasFractionalHeight),
+        (textRounding && !hasFractionalHeight));
+    const float roundedTop = roundValueToPixelGrid(
+        absoluteNodeTop, pointScaleFactor, false, textRounding);
+
+    const float roundedHeight = roundValueToPixelGrid(
+        roundedBottom - roundedTop,
+        pointScaleFactor,
+        false,  // Don't force ceil for height calculation
+        false   // Don't force floor for height calculation
+    );
+
+    node->getLayout().setDimension(Dimension::Height, roundedHeight);
   }
 
   for (yoga::Node* child : node->getChildren()) {


### PR DESCRIPTION
Closes #749 and possibly #1574

The current layout algorithm sometimes rounds down by a small value the size of text nodes, which makes the renderer (at least iOS) skip a line of text, resulting in buggy layout like this:

<img width="1129" height="352" alt="482035993-9f93908b-7068-49eb-aae2-759b55294ced" src="https://github.com/user-attachments/assets/f199fe02-e8af-442d-80d1-c31b5a09aeef" />

I don't have a deep enough understanding of the algorithm to know if this fix is "correct", but what I can say is that:
- it didn't break existing tests
- we didn't get any bug reports while using it in a production app

I only applied the change to the height calculation as I only encountered the issue on height, but I suppose width could benefit from a similar change.