### PR TITLE
fix: incorrect cache validation logic causing cache false hit

### DIFF
--- a/tests/YGMeasureCacheTest.cpp
+++ b/tests/YGMeasureCacheTest.cpp
@@ -176,3 +176,27 @@ TEST(
 
   ASSERT_EQ(1, measureCount);
 }
+
+TEST(YogaTest, remeasure_when_container_grows_with_child_margin) {
+  const YGNodeRef root = YGNodeNew();
+  YGNodeStyleSetWidth(root, 10.f);
+  YGNodeStyleSetHeight(root, 10.f);
+
+  const YGNodeRef child = YGNodeNew();
+  int measureCount = 0;
+  YGNodeSetContext(child, &measureCount);
+  YGNodeSetMeasureFunc(child, _measureMin);
+  YGNodeStyleSetMargin(child, YGEdgeBottom, 5.f);
+  YGNodeInsertChild(root, child, 0);
+
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_EQ(1, measureCount);
+  ASSERT_FLOAT_EQ(5.0f, YGNodeLayoutGetHeight(child));
+
+  YGNodeStyleSetHeight(root, 15.0f);
+  YGNodeCalculateLayout(root, YGUndefined, YGUndefined, YGDirectionLTR);
+  ASSERT_EQ(2, measureCount);
+  ASSERT_FLOAT_EQ(10.0f, YGNodeLayoutGetHeight(child));
+
+  YGNodeFreeRecursive(root);
+}

--- a/yoga/algorithm/Cache.cpp
+++ b/yoga/algorithm/Cache.cpp
@@ -97,7 +97,7 @@ bool canUseCachedMeasurement(
           widthMode,
           availableWidth - marginRow,
           lastWidthMode,
-          lastAvailableWidth,
+          lastAvailableWidth - marginRow,
           lastComputedWidth);
 
   const bool heightIsCompatible = hasSameHeightSpec ||
@@ -112,7 +112,7 @@ bool canUseCachedMeasurement(
       newSizeIsStricterAndStillValid(heightMode,
                                      availableHeight - marginColumn,
                                      lastHeightMode,
-                                     lastAvailableHeight,
+                                     lastAvailableHeight - marginColumn,
                                      lastComputedHeight);
 
   return widthIsCompatible && heightIsCompatible;


### PR DESCRIPTION
## Summary
In `YGLayout.cpp`, when calling `newSizeIsStricterAndStillValid` to check measure cache eligibility, the current constraint `size` is passed as net remaining space (`availableHeight - marginColumn`). However, the historical constraint `lastSize` is erroneously passed as gross space (`lastAvailableHeight`) without subtracting the margin.

This asymmetric comparison (comparing net space with gross space) leads Yoga to falsely assume that the available space has shrunk (triggering the `lastSize > size` branch) when the container actually *grows*. Consequently, a truncated cache result from a previously compressed pass is incorrectly reused.

## Solution
Deduct the corresponding margin size (`marginColumn` / `marginRow`) from `lastAvailableHeight` / `lastAvailableWidth` respectively when calling `newSizeIsStricterAndStillValid` to ensure symmetrical net-to-net boundary comparisons.

## Changelog
[C++] [Fixed] - Correct net layout space comparison in measure cache check by deducting margin.

## Test Plan & Minimal Reproducible Example
Added a new dedicated unit test `remeasure_when_container_grows_with_child_margin` in `YGMeasureCacheTest.cpp`, which serves as a MRE for this specific bug.
- **Before this fix**: The test fails as the child incorrectly hits the stale measure cache and retains a compressed height of 5.0f instead of re-measuring to its desired height of 10.0f.
- **After this fix**: The test passes successfully with all assertions green.


### Reproduction and Verification Steps:
1. **First Layout Pass**: The parent container is initialized with a restricted height (`10.0f`). Due to a child margin (`5.0f`), the net available space for the child is constrained to `5.0f`. The child's measured layout height is compressed to `5.0f` and cached erroneously.
2. **Container Expansion**: The parent container's height expands to `15.0f`, releasing enough net available space (`10.0f`) to completely accommodate the child's desired target height (`10.0f`).
3. **Second Layout Pass (The Bug Location)**: 
   - **Before this fix**: Due to the asymmetric boundary check in `newSizeIsStricterAndStillValid`, Yoga incorrectly triggers a **false cache hit** during the second pass. It blindly reuses the stale, compressed height of `5.0f` from the cache without re-measuring, causing the `measureCount` assertion to fail (retains 1 instead of 2).
   - **After this fix**: Symmetrical net-to-net boundary validation ensures that the cache is properly invalidated when space expands. Yoga correctly triggers a re-measurement (`measureCount` increments to 2) and the child layout height successfully recovers to its correct desired height of `10.0f`. All assertions pass green.
