### PR TITLE
docs: note exception-safe cleanup of JS Yoga trees

### DIFF
--- a/website/docs/getting-started/laying-out-a-tree.mdx
+++ b/website/docs/getting-started/laying-out-a-tree.mdx
@@ -99,6 +99,18 @@ root.insertChild(child1, 1);
 
 Yoga Nodes are not freed automatically and should be discarded when no longer needed. Individual nodes may be freed by calling `node.free()`, or an entire Yoga tree may be freed by calling `node.freeRecursive()`.
 
+Nodes live in the WebAssembly heap, which is not visible to the JavaScript garbage collector. An application which repeatedly leaks nodes will grow the heap until new nodes fail to allocate. If an exception may be thrown after nodes are created (e.g. from within a [measure function](../advanced/external-layout-systems.mdx) during layout), freeing in a `finally` block guarantees the tree is released:
+
+```ts
+const root = buildYogaTree();
+try {
+  root.calculateLayout(undefined, undefined, Direction.LTR);
+  readLayoutResults(root);
+} finally {
+  root.freeRecursive();
+}
+```
+
 A future revision of JavaScript bindings for Yoga may move to garbage collection to remove this requirement.
 
 :::


### PR DESCRIPTION
## Summary

The JavaScript docs already warn that nodes must be freed manually, but don't mention two things we ran into in production (a WASM-based canvas editor that builds a throwaway Yoga tree per layout pass):

1. Nodes live in the WebAssembly heap, so leaked nodes are invisible to the JS garbage collector and accumulate until `Node.create()` fails.
2. If a measure function (or any code between create and free) throws, the whole tree leaks unless freeing happens in a `finally` block.

This adds a short paragraph and a `try`/`finally` example to the existing warning in the JavaScript tab of "Laying out a Yoga tree".

## Test Plan

Docs-only change. Verified the MDX renders (admonition + code fence) and the relative link to `external-layout-systems.mdx` resolves.